### PR TITLE
Cover calculation compatibility with Rideable

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -81,6 +81,9 @@
 
     "tokenvisibility.settings.cover-prone.Name": "Prone Tokens Grant Cover",
     "tokenvisibility.settings.cover-prone.Hint": "If the dead/live token is prone and could otherwise be cover, should it be considered cover?",
+	
+    "tokenvisibility.settings.cover-token-rideable.Name": "Mounts and Riders Grant Cover",
+    "tokenvisibility.settings.cover-token-rideable.Hint": "If the Mounts and Riders of token (as per Rideable) should be considered as cover",
 
     "tokenvisibility.settings.cover-token-live.Name": "Live Tokens Grant Cover",
     "tokenvisibility.settings.cover-token-live.Hint": "'Cover': Token shape contributes to cover. 'Forced': Flat low cover for tokens; token shape not otherwise considered (dnd5e/pf2e). No cover: Tokens do not contribute to cover.",

--- a/scripts/CoverCalculator.js
+++ b/scripts/CoverCalculator.js
@@ -300,6 +300,7 @@ export class CoverCalculator {
     config.liveTokensBlock ??= liveTokenAlg !== liveTypes.NONE;
     config.liveForceHalfCover ??= liveTokenAlg === liveTypes.HALF;
     config.proneTokensBlock ??= getSetting(SETTINGS.COVER.PRONE);
+	config.rideableconnectedTokenBlock ??= getSetting(SETTINGS.COVER.RIDEABLE); //setting for RIDEABLE cover compatibility
 
     this.config = config;
   }
@@ -548,7 +549,7 @@ export class CoverCalculator {
   }
 
   _hasTokenCollision(tokenPoint, targetPoint) {
-    const { liveTokensBlock, deadTokensBlock } = this.config;
+    const { liveTokensBlock, deadTokensBlock, rideableconnectedTokenBlock } = this.config;
     if ( !(liveTokensBlock || deadTokensBlock) ) return false;
 
     const ray = new Ray(tokenPoint, targetPoint);
@@ -558,6 +559,12 @@ export class CoverCalculator {
     tokens.delete(this.viewer);
     tokens.delete(this.target);
 
+	//RIDEABLE COMPATIBILITY
+	//-Filter out all mounts and riders of both this.viewer and this.target if rideableconnectedTokenBlock
+	if (!rideableconnectedTokenBlock && game.modules.get("Rideable").active) {
+		tokens = tokens.filter(token => !game.modules.get("Rideable")?.api?.RidingConnection(token, this.viewer) && !game.modules.get("Rideable")?.api?.RidingConnection(token, this.target))
+	}
+	
     // Build full- or half-height tokenPoints3d from tokens
     const tokenPoints = buildTokenPoints(tokens, this.config);
 

--- a/scripts/CoverCalculator.js
+++ b/scripts/CoverCalculator.js
@@ -560,7 +560,7 @@ export class CoverCalculator {
     tokens.delete(this.target);
 
 	//RIDEABLE COMPATIBILITY
-	//-Filter out all mounts and riders of both this.viewer and this.target if rideableconnectedTokenBlock
+	//-Filter out all mounts and riders of both this.viewer and this.target if  not rideableconnectedTokenBlock
 	if (!rideableconnectedTokenBlock && game.modules.get("Rideable").active) {
 		tokens = tokens.filter(token => !game.modules.get("Rideable")?.api?.RidingConnection(token, this.viewer) && !game.modules.get("Rideable")?.api?.RidingConnection(token, this.target))
 	}

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -10,6 +10,7 @@ import { MODULE_ID, COVER, DEBUG, setCoverIgnoreHandler } from "./const.js";
 import { registerGeometry } from "./geometry/registration.js";
 import { initializePatching, PATCHER } from "./patching.js";
 import {
+  SETTINGS,
   registerSettings,
   updateConfigStatusEffects,
   getSetting,
@@ -99,6 +100,19 @@ Hooks.once("setup", function() {
   updateConfigStatusEffects();
 });
 
+Hooks.on('createActiveEffect', refreshVisionOnActiveEffect);
+Hooks.on('deleteActiveEffect', refreshVisionOnActiveEffect);
+
+/**
+ * Refresh vision for relevant active effect creation/deletion
+ */
+function refreshVisionOnActiveEffect(activeEffect) {
+  const proneStatusId = CONFIG.GeometryLib.proneStatusId ?? getSetting(SETTINGS.COVER.LIVE_TOKENS.ATTRIBUTE);
+  const isProne = activeEffect?.statuses.some((status) => status === proneStatusId);
+  if ( !isProne ) return;
+
+  canvas.effects.visibility.refresh();
+}
 
 /**
  * Tell DevMode that we want a flag for debugging this module.

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -137,7 +137,9 @@ export const SETTINGS = {
       }
     },
 
-    PRONE: "cover-prone"
+    PRONE: "cover-prone",
+	
+	RIDEABLE: "cover-token-rideable"
   },
 
   CHANGELOG: "changelog",
@@ -463,6 +465,15 @@ export function registerSettings() {
     config: true,
     type: Boolean,
     default: true
+  });
+  
+  game.settings.register(MODULE_ID, SETTINGS.COVER.RIDEABLE, { //for RIDEABLE include connected tokens for cover
+    name: game.i18n.localize(`${MODULE_ID}.settings.${SETTINGS.COVER.RIDEABLE}.Name`),
+    hint: game.i18n.localize(`${MODULE_ID}.settings.${SETTINGS.COVER.RIDEABLE}.Hint`),
+    scope: "world",
+    config: game.modules.get("Rideable")?.active,
+    type: Boolean,
+    default: false
   });
 
   game.settings.register(MODULE_ID, SETTINGS.COVER.DEAD_TOKENS.ATTRIBUTE, {


### PR DESCRIPTION
Adds the setting "Mounts and Riders Grant Cover" allowing GMs to remove Rideable Mounts/Riders from the cover calculations for a given token.
I tried to implement the changes as non invasive as possible and to stick to your structure, i hope i haven't missed something.